### PR TITLE
Fix for -excludepatterns

### DIFF
--- a/bdcustomscan.sh
+++ b/bdcustomscan.sh
@@ -57,7 +57,7 @@ then
 fi
 if [ ! -z "$EXCLUDEPATTERNS" ]
 then
-	SCANOPTS="$SCANOPTS -excludepatterns $EXCLUDELIST"
+	SCANOPTS="$SCANOPTS -excludepatterns $EXCLUDEPATTERNS"
 fi
 
 "$BDSCANFOCUSDIR/focus_scan.sh" $SCANOPTS -jsonfile $JSONSCANFILE -jsonout ${TEMPFILE}_mod.json


### PR DESCRIPTION
$EXCLUDEPATTERNS shall be used instead of the undeclared $EXCLUDELIST, otherwise the exclusionpatterns list will not be passed to the focus_scan script